### PR TITLE
Extra validations and flash messaging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,17 @@ gem 'rake'
 gem 'sinatra'
 gem 'sinatra-activerecord'
 gem 'sinatra-contrib'
+gem 'sinatra-flash'
 
 group :test, :development do
   gem 'database_cleaner'
   gem 'capybara'
   gem 'pry'
   gem 'rspec'
+end
+
+group :test do
+  gem "shoulda"
+  gem "shoulda-matchers", "~> 2.4.0", require: false
+  gem "valid_attribute"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,13 +8,13 @@ gem 'sinatra-contrib'
 gem 'sinatra-flash'
 
 group :test, :development do
-  gem 'database_cleaner'
-  gem 'capybara'
   gem 'pry'
-  gem 'rspec'
 end
 
 group :test do
+  gem 'rspec'
+  gem 'database_cleaner'
+  gem 'capybara'
   gem "shoulda"
   gem "shoulda-matchers", "~> 2.4.0", require: false
   gem "valid_attribute"

--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ that includes:
 - [Active Record](http://guides.rubyonrails.org/active_record_querying.html)
 using [sinatra-activerecord](https://github.com/janko-m/sinatra-activerecord)
 - [PostgreSQL](http://www.postgresql.org/) for a database
+- [Sinatra Flash](https://github.com/SFEley/sinatra-flash) to easily show messages to the user (`flash[:notice] = "Flash message to the user!"`)
 - [Sinatra::Reloader](http://www.sinatrarb.com/contrib/reloader.html) to
   automatically reload modified files during development
 - [RSpec](https://github.com/rspec/rspec) for unit testing
 - [Capybara](https://github.com/jnicklas/capybara) for acceptance testing
 - [Pry](https://github.com/pry/pry) for debugging
+- [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) to more easily test model associations (e.g., `it { should belong_to :user }`)
+- [Valid Attribute](https://github.com/bcardarella/valid_attribute) to more easily test model attributes (e.g., `it { should have_valid(:username).when("valid_username") }`)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ rake db:test:prepare      # Prepare test database from development schema
 
 Uses [Sinatra Flash](https://github.com/SFEley/sinatra-flash)
 
-Flash messages allow you to send information across page redirects. However, only short messages may be sent. Long messages or large objects tend to result in the Flash messages being cleared. In the layout page, a placeholder for `flash[:notice]` has already been added.
+Flash messages allow you to send information across page redirects. However, only short messages may be sent. Long messages or large objects tend to result in the Flash messages being cleared. In the `/app/views/layout.erb`, a message box for `flash[:notice]` has already been added.
 
 **Example:**
 ```ruby
@@ -90,7 +90,7 @@ end
 
 ## Shoulda Matchers
 
-Uses [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) to more easily test model associations (e.g., )
+Uses [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers)
 
 Shoulda Matchers allow for easier testing of Model associations in your unit tests using RSpec.
 
@@ -103,8 +103,8 @@ require 'spec_helper'
 # In this example, a user can have many books,
 # but may only belong to a single library.
 describe User do
-  it { should have_many :books }
   it { should belong_to :library }
+  it { should have_many :books }
 end
 
 ```
@@ -113,6 +113,7 @@ end
 # /app/models/user.rb
 
 class User < ActiveRecord::Base
+  # Note the difference in "belongs_to" here vs. "belong_to" in the spec test.
   belongs_to :library
   has_many :books
 end

--- a/README.md
+++ b/README.md
@@ -6,14 +6,12 @@ that includes:
 - [Active Record](http://guides.rubyonrails.org/active_record_querying.html)
 using [sinatra-activerecord](https://github.com/janko-m/sinatra-activerecord)
 - [PostgreSQL](http://www.postgresql.org/) for a database
-- [Sinatra Flash](https://github.com/SFEley/sinatra-flash) to easily show messages to the user (`flash[:notice] = "Flash message to the user!"`)
 - [Sinatra::Reloader](http://www.sinatrarb.com/contrib/reloader.html) to
   automatically reload modified files during development
 - [RSpec](https://github.com/rspec/rspec) for unit testing
 - [Capybara](https://github.com/jnicklas/capybara) for acceptance testing
 - [Pry](https://github.com/pry/pry) for debugging
-- [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) to more easily test model associations (e.g., `it { should belong_to :user }`)
-- [Valid Attribute](https://github.com/bcardarella/valid_attribute) to more easily test model attributes (e.g., `it { should have_valid(:username).when("valid_username") }`)
+
 
 ## Getting Started
 
@@ -55,4 +53,94 @@ rake db:schema:load       # load schema into database
 rake db:seed              # load the seed data from db/seeds.rb
 rake db:setup             # create the database and load the schema
 rake db:test:prepare      # Prepare test database from development schema
+```
+
+## Flash Notices
+
+Uses [Sinatra Flash](https://github.com/SFEley/sinatra-flash)
+
+Flash messages allow you to send information across page redirects. However, only short messages may be sent. Long messages or large objects tend to result in the Flash messages being cleared. In the layout page, a placeholder for `flash[:notice]` has already been added.
+
+**Example:**
+```ruby
+# app.rb
+
+post '/books' do
+  # do some logic like save something to the database
+  flash[:notice] = "Your book was saved!"
+
+  redirect '/books/all'
+end
+
+get '/books/all' do
+  # Some code or logic to get all books
+
+  erb :'books/index'
+  # Flash message will appear on this page
+end
+
+# HEADS UP - flash does not work if returning a view
+get '/books/all' do
+  flash[:notice] = "This will not appear on the page."
+
+  erb :'/books/index'
+  # No flash message will appear until you navigate to a new page or the page refreshes.
+end
+```
+
+## Shoulda Matchers
+
+Uses [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) to more easily test model associations (e.g., )
+
+Shoulda Matchers allow for easier testing of Model associations in your unit tests using RSpec.
+
+**Example:**
+
+```ruby
+# /spec/models/user_spec.rb
+
+require 'spec_helper'
+# In this example, a user can have many books,
+# but may only belong to a single library.
+describe User do
+  it { should have_many :books }
+  it { should belong_to :library }
+end
+
+```
+
+```ruby
+# /app/models/user.rb
+
+class User < ActiveRecord::Base
+  belongs_to :library
+  has_many :books
+end
+```
+
+## Valid Attribute
+
+Uses [Valid Attribute](https://github.com/bcardarella/valid_attribute)
+
+Valid Attribute allows for the rapid development of tests for validations
+in your models.
+
+**Example:**
+
+```ruby
+# /spec/models/user_spec.rb
+
+describe User do
+  it { should have_valid(:username).when("valid_username", "another_valid_username") }
+  it { should_not have_valid(:username).when('', nil) }
+end
+
+```
+
+```ruby
+# /app/models/user.rb
+
+class User < ActiveRecord::Base
+  validates :username, presence: true
+end
 ```

--- a/app.rb
+++ b/app.rb
@@ -1,6 +1,8 @@
 require 'sinatra'
 require 'sinatra/activerecord'
 require 'sinatra/reloader'
+require 'sinatra/flash'
+
 
 configure :development, :test do
   require 'pry'

--- a/app.rb
+++ b/app.rb
@@ -3,6 +3,7 @@ require 'sinatra/activerecord'
 require 'sinatra/reloader'
 require 'sinatra/flash'
 
+enable :sessions
 
 configure :development, :test do
   require 'pry'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,9 @@ require 'capybara/rspec'
 require_relative 'support/database_cleaner'
 require_relative '../app.rb'
 
+require 'valid_attribute'
+require 'shoulda/matchers'
+
 set :environment, :test
 set :database, :test
 


### PR DESCRIPTION
This pull request adds three features to the Sinatra Starter Kit: Shoulda Matchers, Validate Attribute, and Flash messaging. 

The two testing helpers (Shoulda Matchers and Validate Attribute) are a bit tricky to setup in Sinatra (without Rails), but are required in lessons before Rails is introduced (e.g., https://learn.launchacademy.com/teams/summer-2016/curricula/onsite/lessons/testing-activerecord-associations). Allowing these features in a Sinatra application may make these lessons easier to consume.

Flash messaging is also a common feature in the challenges that use Sinatra and is also a bit tricky to setup.

I tested all of these added features, but then deleted the extra routes and specs I used to test the features to clean up the starter files.

I'm also doing this because as a current Launch Student, I've never attempted a Pull Request and thought it might be a useful time to try it out.