### PR TITLE
Removed version specifier on activerecord

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 4.1"
+gem "activerecord"
 gem "pg"
 gem "rake"
 gem "sinatra", "~> 1.4"


### PR DESCRIPTION
with old version specifier on ActiveRecord out test suite (rspec) will error out when run.  removing the version specifier fixes this issue (with version 5.1.3)